### PR TITLE
Improve login detection

### DIFF
--- a/src/backend/src/execution/login/find_form_automatically.py
+++ b/src/backend/src/execution/login/find_form_automatically.py
@@ -42,48 +42,47 @@ def _find_username_field(sd: SeleniumDriver, dom: HTML) -> XPath | None:
     """
     Tries to find xpath of username field automatically.
     """
-    tag_types = ["input"]
+    tag_scores = [("input", Score(8))]
     id_aliases = ["email", "e-mail", "username", "user", "uid"]
     type_scores = [("email", Score(10)), ("text", Score(1))]
     property_scores = [("@name", Score(10)), ("@id", Score(10)), ("@class", Score(2)), ("@autocomplete", Score(10)), ("@placeholder", Score(3))]
-    return _find_form_field(sd, dom, tag_types, id_aliases, type_scores, property_scores)
+    return _find_form_field(sd, dom, id_aliases, tag_scores, type_scores, property_scores)
 
 
 def _find_password_field(sd: SeleniumDriver, dom: etree.HTML) -> XPath | None:
     """
     Tries to find xpath of password field automatically.
     """
-    tag_types = ["input"]
+    tag_scores = [("input", Score(8))]
     id_aliases = ["password", "pwd"]
     type_scores = [("password", Score(10)), ("text", Score(1))]
     property_scores = [("@name", Score(10)), ("@id", Score(10)), ("@class", Score(2)), ("@autocomplete", Score(10)), ("@placeholder", Score(3))]
-    return _find_form_field(sd, dom, tag_types, id_aliases, type_scores, property_scores)
+    return _find_form_field(sd, dom, id_aliases, tag_scores, type_scores, property_scores)
 
 
 def _find_pin_field(sd: SeleniumDriver, dom: HTML) -> XPath | None:
     """
     Tries to find xpath of pin field automatically.
     """
-    tag_types = ["input"]
+    tag_scores = [("input", Score(8))]
     id_aliases = ["pin"]
     type_scores = [("number", Score(10)), ("text", Score(1))]
     property_scores = [("@name", Score(10)), ("@id", Score(10)), ("@class", Score(2)), ("@autocomplete", Score(10)), ("@placeholder", Score(3))]
-    return _find_form_field(sd, dom, tag_types, id_aliases, type_scores, property_scores)
+    return _find_form_field(sd, dom, id_aliases, tag_scores, type_scores, property_scores)
 
 
 def _find_submit_button(sd: SeleniumDriver, dom: HTML) -> XPath | None:
     """
     Tries to find xpath of submit button automatically.
     """
-    tag_types = ["button", "input", "div"]
+    tag_scores = [("button", Score(8)), ("input", Score(8)), ("div", Score(1))]
     id_aliases = ["login", "log in", "log-in", "signin", "sign in", "sign-in", "submit"]
     type_scores = [("submit", Score(10)), ("button", Score(10))]
     property_scores = [("@name", Score(10)), ("@id", Score(10)), ("@class", Score(2)), ("@value", Score(3)), ("text()", Score(10))]
-    best = _find_form_field(sd, dom, tag_types, id_aliases, type_scores, property_scores)
-    print("bst", best)
-    return best
+    return _find_form_field(sd, dom, id_aliases, tag_scores, type_scores, property_scores)
 
-def _find_form_field(sd: SeleniumDriver, dom: HTML, tag_types: List[str], id_aliases: List[str], type_scores: List[Tuple[str, Score]], property_scores: List[Tuple[str, Score]]) -> XPath | None:
+
+def _find_form_field(sd: SeleniumDriver, dom: HTML, id_aliases: List[str], tag_scores: List[Tuple[str, Score]], type_scores: List[Tuple[str, Score]], property_scores: List[Tuple[str, Score]]) -> XPath | None:
     """
     Tries to find xpath of form field automatically.
     @param dom: The lxml dom that is used for parsing.
@@ -94,14 +93,14 @@ def _find_form_field(sd: SeleniumDriver, dom: HTML, tag_types: List[str], id_ali
     @return: XPaths object. None if no element is found.
     """
     selector_scoring = {}
-    for i, tag_type in enumerate(tag_types):
+    selector_scoring = _find_by_tag(dom, selector_scoring, tag_scores)
+    for i, (tag_type, tag_score) in enumerate(tag_scores):
         selector_scoring = _find_by_type(dom, selector_scoring, tag_type, type_scores)
         selector_scoring = _find_by_property(dom, selector_scoring, tag_type, id_aliases, property_scores)
         selector_scoring = _find_by_dom_text(dom, selector_scoring, tag_type, id_aliases)
 
     selector_scoring = _remove_if_hidden(selector_scoring)
     selector_scoring = _find_by_form_child(selector_scoring)
-    print(selector_scoring)
     # Get element with the highest score
     return _find_best_element(sd, selector_scoring)
 
@@ -120,6 +119,15 @@ def _find_best_element(sd: SeleniumDriver, scoring: Scoring) -> XPath | None:
     # Best element is not visible -> remove from scoring
     del scoring[best_element]
     return _find_best_element(sd, scoring)
+
+
+def _find_by_tag(dom: etree.HTML, scoring: Scoring, tag_scores: List[Tuple[str, Score]]) -> Scoring:
+    """
+    Finds element by tag and adds it to the scoring dictionary.
+    """
+    for tag_type, score in tag_scores:
+        scoring = _find_element(dom, scoring, XPath(f"//{tag_type}"), score)
+    return scoring
 
 
 def _find_by_type(dom: etree.HTML, scoring: Scoring, tag_type: str, type_scores: List[Tuple[str, Score]]) -> Scoring:
@@ -218,6 +226,7 @@ def _add_score_to_element(element: Element, scoring: Scoring, xpath: str, score:
     else:
         scoring[element] = ([xpath], score)
     return scoring
+
 
 def _remove_if_hidden(scoring: Scoring) -> Scoring:
     """

--- a/src/backend/src/execution/login/login.py
+++ b/src/backend/src/execution/login/login.py
@@ -78,7 +78,7 @@ def login(
 
             # Wait for expected url
             for i in range(TIMEOUT):
-                sb.uc_gui_handle_captcha()  
+                sb.uc_gui_handle_captcha()
                 sb.uc_gui_click_captcha()
                 sb.sleep(1)
                 if sb.cdp.get_current_url() == success_url:

--- a/src/backend/src/execution/login/login.py
+++ b/src/backend/src/execution/login/login.py
@@ -39,6 +39,7 @@ def login(
 
             # Wait until paths are found
             for i in range(0, TIMEOUT, 5):
+                sb.uc_gui_handle_captcha()
                 sb.uc_gui_click_captcha()
                 elements, error = find_elements(sb=sb, x_paths=x_paths, pin=pin)
                 if elements is not None:
@@ -77,6 +78,7 @@ def login(
 
             # Wait for expected url
             for i in range(TIMEOUT):
+                sb.uc_gui_handle_captcha()  
                 sb.uc_gui_click_captcha()
                 sb.sleep(1)
                 if sb.cdp.get_current_url() == success_url:

--- a/src/backend/tests/endpoints/login_html_examples/find_by_form_parent.html
+++ b/src/backend/tests/endpoints/login_html_examples/find_by_form_parent.html
@@ -1,4 +1,4 @@
-<!-- Find by id -->
+<!-- Find by form parent -->
 <html>
     <form>
         <input id="username" test-id="username"/>

--- a/src/backend/tests/endpoints/login_html_examples/find_by_form_parent.html
+++ b/src/backend/tests/endpoints/login_html_examples/find_by_form_parent.html
@@ -1,0 +1,11 @@
+<!-- Find by id -->
+<html>
+    <form>
+        <input id="username" test-id="username"/>
+        <input id="password" test-id="password"/>
+        <button id="login" test-id="submit-button">Login</button>
+    </form>
+    <input id="username" name="username"/>
+    <input id="password" name="password"/>
+    <button id="login" name="submit-button">Login</button>
+</html>

--- a/src/backend/tests/endpoints/test_find_form_automatically.py
+++ b/src/backend/tests/endpoints/test_find_form_automatically.py
@@ -24,17 +24,15 @@ def test_find_login_automatically(filename):
     examples_dir = os.path.join(current_dir, "login_html_examples")
     filepath = os.path.join(examples_dir, filename)
 
-    with open(filepath, 'r') as file:
+    with open(filepath, 'r', encoding="utf-8") as file:
         content = file.read()
         selenium_driver = SeleniumTestDriverElementsAlwaysVisible()
         xpaths = find_login_automatically(selenium_driver, content, False)
         assert xpaths is not None, f"Found no xpath for login {filename}"
 
         dom = HTML(content)
-        print(content)
         username_element = dom.xpath(xpaths.username)
-        print(xpaths.username[0])
-        print(username_element)
+
         assert len(username_element) == 1, f"Found no username element for login {filename}"
         assert username_element[0].get("test-id") == "username", f"Found wrong username element for login {filename}"
 


### PR DESCRIPTION
- Elements with `form` as parent now receive a higher score, because login inputs are often inside a form
- Assign lower score to css `class` content, because some sites might use classnames that contain to many keywords
- Assign scores to `tag` elements
- Improve turnstile captcha solving